### PR TITLE
Make slack log link work for ECS containers in other regions

### DIFF
--- a/cluster.template
+++ b/cluster.template
@@ -39,7 +39,10 @@
               "awslogs-region": {"Ref": "AWS::Region"}
             }
           },
-          "Environment": [{"Name": "LOG_GROUP", "Value": {"Ref": "EcsLogs"}}],
+          "Environment": [
+            {"Name": "LOG_GROUP", "Value": {"Ref": "EcsLogs"}},
+            {"Name": "AWS_REGION","Value": {"Ref": "AWS::Region"}}
+           ],
           "MountPoints": [{"SourceVolume": "docker-socket", "ContainerPath": "/var/run/docker.sock"}]
         }],
         "Volumes": [{"Name": "docker-socket", "Host": {"SourcePath": "/var/run/docker.sock"}}]


### PR DESCRIPTION
This passes the AWS_REGION environment parameter to the container, so that it can then provide the correct cloudwatch log link to slack when it notifies of success or failure.

Without this, the container does not have the AWS_REGION variable, and therefore cannot construct the cloudwatch log link correctly. See [the relevant line in common.sh](https://github.com/lambci/ecs/blob/3619ca06a4771faa9301b0de4f411fbcfb776c23/common.sh#L96).