### PR TITLE
Update AMIs to 2016.03.g and include missing regions

### DIFF
--- a/cluster.template
+++ b/cluster.template
@@ -11,14 +11,17 @@
   },
   "Mappings": {
     "EcsAmisByRegion": {
-      "us-east-1": {"ami": "ami-a88a46c5"},
-      "us-west-1": {"ami": "ami-34a7e354"},
-      "us-west-2": {"ami": "ami-ae0acdce"},
-      "eu-west-1": {"ami": "ami-ccd942bf"},
-      "eu-central-1": {"ami": "ami-4a5eb625"},
-      "ap-northeast-1": {"ami": "ami-4aab5d2b"},
-      "ap-southeast-1": {"ami": "ami-24c71547"},
-      "ap-southeast-2": {"ami": "ami-0bf2da68"}
+      "us-east-1": {"ami": "ami-275ffe31"},
+      "us-east-2": {"ami": "ami-62745007"},
+      "us-west-1": {"ami": "ami-689bc208"},
+      "us-west-2": {"ami": "ami-62d35c02"},
+      "eu-west-1": {"ami": "ami-95f8d2f3"},
+      "eu-west-2": {"ami": "ami-bf9481db"},
+      "eu-central-1": {"ami": "ami-085e8a67"},
+      "ap-northeast-1": {"ami": "ami-f63f6f91"},
+      "ap-southeast-1": {"ami": "ami-b4ae1dd7"},
+      "ap-southeast-2": {"ami": "ami-fbe9eb98"},
+      "ca-central-1": {"ami": "ami-ee58e58a"},
     }
   },
   "Resources": {
@@ -134,4 +137,3 @@
     }
   }
 }
-

--- a/cluster.template
+++ b/cluster.template
@@ -21,7 +21,7 @@
       "ap-northeast-1": {"ami": "ami-f63f6f91"},
       "ap-southeast-1": {"ami": "ami-b4ae1dd7"},
       "ap-southeast-2": {"ami": "ami-fbe9eb98"},
-      "ca-central-1": {"ami": "ami-ee58e58a"},
+      "ca-central-1": {"ami": "ami-ee58e58a"}
     }
   },
   "Resources": {


### PR DESCRIPTION
The goal of this PR is to update AWS ECS optimized AMIs from version `03.2016.d` to `09.2016.g` and include the missing regions: `us-east-2`, `eu-west-2`, and `ca-central-1`.

Fulfills #13 