### PR TITLE
ecs + custom stack name

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -20,6 +20,8 @@ export LOG_FILE="${SCRIPT_DIR}/lambci.log"
 export LOG_GROUP="${LOG_GROUP:-/lambci/ecs}"
 export LOG_STREAM="${LOG_STREAM:-$CONTAINER_ID}"
 
+export STACK="${STACK:-lambci}"
+
 cleanup() {
   EXIT_STATUS=$1
 
@@ -41,7 +43,7 @@ github_status() {
   "state": "'"$1"'",
   "description": "'"$2"'",
   "target_url": "'"$(aws_log_url)"'",
-  "context": "continuous-integration/lambci"
+  "context": "continuous-integration/'"${STACK}"'"
 }'
 }
 


### PR DESCRIPTION
overview
---

when using a custom stack name, the docker ecs image does not properly report back to the correct ci instance on github because it was hard coded to the default value

tasks
---
- [x] infer the ci instance from stack name
- [x] build and push new docker image to `slajax/lambci`
- [x] build and test with `slajax/lambci` and lambci/lambci#91
- [ ] build and push new docker image to `lambci/ecs`

closes #17 
